### PR TITLE
Moved everything into namespace lime

### DIFF
--- a/examples/calc/calc.class
+++ b/examples/calc/calc.class
@@ -13,6 +13,7 @@
  * If you ignore this warning, you're shooting yourself in the brain,
  * not the foot.
  */
+namespace lime;
 class calc extends lime_parser {
   public $qi = 0;
   public $i = array(
@@ -504,7 +505,7 @@ class calc extends lime_parser {
   }
 
   function reduce_15_param_list_1($tokens, &$result) {
-    // (15) param_list :=
+    // (15) param_list :=  ε
     $result = reset($tokens);
 
     $result = array();
@@ -661,5 +662,5 @@ class calc extends lime_parser {
   );
 }
 
-// Time: 0.093108177185059 seconds
-// Memory: 2768108 bytes
+// Time: 0.02726411819458 seconds
+// Memory: 3137008 bytes

--- a/examples/calc/calc.php
+++ b/examples/calc/calc.php
@@ -1,10 +1,11 @@
+<?php namespace lime; ?>
 This program is like a calculator. Type in lines of math, and it will
 print the results. You can set a variable with:
 	foo = 12 + 7.3
 and use it in another calculation like:
 	23.14 - foo
 
-<?
+<?php
 
 include_once "../../parse_engine.php";
 include_once "calc.class";

--- a/examples/error/error.class
+++ b/examples/error/error.class
@@ -13,6 +13,7 @@
  * If you ignore this warning, you're shooting yourself in the brain,
  * not the foot.
  */
+namespace lime;
 class parser extends lime_parser {
   public $qi = 0;
   public $i = array(
@@ -149,5 +150,5 @@ class parser extends lime_parser {
   );
 }
 
-// Time: 0.032855033874512 seconds
-// Memory: 1516852 bytes
+// Time: 0.0099399089813232 seconds
+// Memory: 1577792 bytes

--- a/examples/error/error.php
+++ b/examples/error/error.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace lime;
 include_once "../../parse_engine.php";
 include_once "error.class";
 

--- a/flex_token_stream.php
+++ b/flex_token_stream.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace lime;
 /**
  * Let's face it: PHP is not up to lexical processing. GNU flex handles
  * it well, so I've created a little protocol for delegating the work.

--- a/lime.php
+++ b/lime.php
@@ -1,5 +1,6 @@
 #!/usr/bin/php -q
-<?php
+<?php namespace lime;
+
 /*
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ function emit($str) {
 	fputs(STDERR, $str . PHP_EOL);
 }
 
-class Bug extends Exception {
+class Bug extends \Exception {
 }
 
 function bug($gripe = 'Bug found.') {
@@ -240,7 +241,7 @@ class accept extends step {
 	}
 }
 
-class RRC extends Exception {
+class RRC extends \Exception {
 	public function __construct($a, $b) {
 		parent::__construct('Reduce-Reduce Conflict');
 
@@ -1103,7 +1104,7 @@ class lime_language_php extends lime_language {
 		$code .= 'public $method = ' . lime_export($method, true) . ';' . PHP_EOL;
 		$code .= 'public $a = '.lime_export($rules, true) . ';' . PHP_EOL;
 
-		return 'class ' . $parser_class . ' extends lime_parser {' . PHP_EOL .
+		return "namespace lime;\nclass " . $parser_class . ' extends lime_parser {' . PHP_EOL .
 			preg_replace(array('~^~m', '~^\h+$~m'), array(INDENT, ''), $code) .
 		'}' . PHP_EOL;
 	}

--- a/parse_engine.php
+++ b/parse_engine.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace lime;
 /**
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,13 +23,13 @@ abstract class lime_parser {
 /**
  * The input doesn't match the grammar
  */
-class parse_error extends Exception {
+class parse_error extends \Exception {
 }
 
 /**
  * Bug, I made a mistake
  */
-class parse_bug extends Exception {
+class parse_bug extends \Exception {
 }
 
 class parse_unexpected_token extends parse_error {

--- a/set.so.php
+++ b/set.so.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace lime;
 
 /*
 File: set.so.php


### PR DESCRIPTION
Lime declares a class named "Error". PHP also declares a class with that
name since PHP 7. To solve the resulting "PHP Fatal error: Cannot declare
class error, because the name is already in use", all Lime code was
moved into namespace lime.